### PR TITLE
docs: Add warning about not using secrets within `.env` files

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,6 @@ LOG_LEVEL=info
 
 MAIL_HOST=smtp.sendgrid.net
 MAIL_PORT=587
-MAIL_USERNAME=apikey
-MAIL_PASSWORD=sendgrid_api_key
 MAIL_ENCRYPTION=tls
 MAIL_FROM_NAME="John Smith"
 MAIL_FROM_ADDRESS=from@example.com

--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ manage. This GitHub Action should help relieve some of the pains by:
 
 ---
 
+> [!CAUTION]
+>
+> Do not pass sensitive data within your `.env` files as it will be added as a
+> plain text environment variable on the container.
+>
+> Use `env[].valueFrom.secretKeyRef` on the container instead to reference
+> secrets.
+
+---
+
 - [Usage](#usage)
 - [Examples](#examples)
 - [Customizing](#customizing)


### PR DESCRIPTION
The current examples in the README could be a bit misleading as it contains the `"sendgrid_api_key"` example, which is a bit misrepresentative. Instead we're now adding a banner with a warning and removing the secrets to not mislead.